### PR TITLE
Change Hapi PeerDependency and change route options

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "ISC",
 	"peerDependencies": {
-		"hapi": "^14.0.0"
+		"hapi": ">=14.x.x"
 	},
   "devDependencies": {
     "chai": "^1.9.2",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -148,8 +148,9 @@ exports.register = function (server, opts, next) {
 				}
 			},
 			config: {
-				auth: false
-
+				auth: {
+					mode: 'try'
+				}
 			}
 		});
 


### PR DESCRIPTION
Hi  @atroo,

i would like to suggest to support the next major releases of hapi by changing the peer dependency. 

Also it would be nice if the dev view route could use auth mode _try_ instead of _false_. This would pass any configured auth scheme first and gives the index dev view the possibility to access the "right" credentials in _request.auth_ [request properties](http://hapijs.com/api#request-properties).